### PR TITLE
Correct quotation marks in background images for desktop version.

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7,7 +7,7 @@
   }
 
   body {
-    background-image: url(/images/bg-header.png);
+    background-image: url(/images/"bg-header.png");
     background-size: 100%;
     background-position: 0% -1.5%;
     background-repeat: no-repeat;
@@ -474,7 +474,7 @@
   /* Contact form section */
   #foot {
     box-sizing: border-box;
-    background: url("/images/bg-contact.png");
+    background: url(/images/"bg-contact.png");
     background-size: cover;
     background-position: right 100% top 0%;
     background-repeat: no-repeat;
@@ -606,7 +606,7 @@
 
   body {
     background-position: 0% 1.5%;
-    background-image: url(/images/headline-background-mobile.png);
+    background-image: url(/images/"headline-background-mobile.png");
     background-size: 100%;
     background-repeat: no-repeat;
   }


### PR DESCRIPTION
This Pull Request is only to update the errors in the css/styles.css file, in order to show properly the background images in the Heading and in the Contact form. The name of the files needed to be inside quotation marks.