### PR TITLE
Correct again quotation marks in background images for desktop version.

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7,7 +7,7 @@
   }
 
   body {
-    background-image: url(/images/"bg-header.png");
+    background-image: url("/images/bg-header.png");
     background-size: 100%;
     background-position: 0% -1.5%;
     background-repeat: no-repeat;
@@ -474,7 +474,7 @@
   /* Contact form section */
   #foot {
     box-sizing: border-box;
-    background: url(/images/"bg-contact.png");
+    background: url("/images/bg-contact.png");
     background-size: cover;
     background-position: right 100% top 0%;
     background-repeat: no-repeat;
@@ -606,7 +606,7 @@
 
   body {
     background-position: 0% 1.5%;
-    background-image: url(/images/"headline-background-mobile.png");
+    background-image: url("/images/headline-background-mobile.png");
     background-size: 100%;
     background-repeat: no-repeat;
   }


### PR DESCRIPTION
I'm creating this new pull request to correct a small error while writing the names of the background images for the desktop version (they are not showing when deployed, even though they show when using VS Code). The error relates to the correct use of quotation marks for the file names.